### PR TITLE
Revert "Skip failing test for now"

### DIFF
--- a/src/format/__tests__/formatGemStats.ts
+++ b/src/format/__tests__/formatGemStats.ts
@@ -80,8 +80,7 @@ it('should only translate the lines that have translations', () => {
   ]);
 });
 
-// FIXME: doesnt have to have any granted effects anymore
-it.skip('should use the specified files first', () => {
+it('should use the specified files first', () => {
   const vitality_effects = formatGemStats(
     'vitality',
     [


### PR DESCRIPTION
This reverts commit 3f58429556126c6dce875885551eadd6ca23e221.
Was failing because of missing translation data which was added in 572bf9824e3a43d04e8e5e5e9925aecf0954fdc2.