### PR TITLE
Fix formater if required

### DIFF
--- a/src/localize/__tests__/formatters.ts
+++ b/src/localize/__tests__/formatters.ts
@@ -32,7 +32,7 @@ it('should match all the formats', () => {
   expect(factory('per_minute_to_per_second_2dp')(6)).toBe('0.10');
 
   expect(factory('per_minute_to_per_second_2dp_if_required')(10)).toBe('0.17');
-  expect(factory('per_minute_to_per_second_2dp_if_required')(60)).toBe('1.0');
+  expect(factory('per_minute_to_per_second_2dp_if_required')(60)).toBe('1');
   expect(factory('per_minute_to_per_second_2dp_if_required')(66)).toBe('1.1');
 
   expect(factory('milliseconds_to_seconds_0dp')(100)).toBe('0');

--- a/src/localize/formatters.ts
+++ b/src/localize/formatters.ts
@@ -19,7 +19,8 @@ const formatters: { [key: string]: Formatter } = {
   old_leech_permyriad: n => n / 50,
   per_minute_to_per_second_0dp: n => (n / 60).toFixed(0),
   per_minute_to_per_second_2dp: n => (n / 60).toFixed(2),
-  per_minute_to_per_second_2dp_if_required: n => (n / 60).toPrecision(2),
+  per_minute_to_per_second_2dp_if_required: n =>
+    (n / 60).toFixed(2).replace(/\.?0*$/, ''),
   milliseconds_to_seconds_0dp: n => (n / 1000).toFixed(0),
   milliseconds_to_seconds_2dp: n => (n / 1000).toFixed(2),
   multiplicative_damage_modifier: n => n,


### PR DESCRIPTION
`toPrecision` does not discriminate between digits before or after comma. `toFixed` with an additional replace of trailing zeros fits our use case.