### PR TITLE
Text to stats api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/eps1lon/poe-i18n/compare/v0.7.1..HEAD)
+## [Unreleased](https://github.com/eps1lon/poe-i18n/compare/v0.7.1...HEAD)
 ### Added 
 - `locale-data` for Path Of Exile@3.1.3 (#14)
 - Typescript declaration files (#18)

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,7 +12,7 @@ An inflection identifier consists of a gender identifier (`M` for masculine,
 identifier can for example be found in `BaseItemtypes` to pass to the `Mods` message. 
 
 ## Format
-Wrapper for `formatStats` and `formatGemStats` with global configuration.
+Wrapper for `formatStats`, `formatGemStats`, and `textToStats` with global configuration.
 An instance of this is exported in `format`.
 ### Format#configure(options: Options)
 Configures behavior of `formatStats` and `formatGemStats`
@@ -23,6 +23,9 @@ Partially applied [formatStats](#formatStats) with options that were previously
 applied by `#configure`
 ### Format#gemStats
 Same behavior as `#stats` but for [formatGemStats](#formatGemStats).
+### Format#textToStats
+Partially applied [textToStats](#textToStats) with options that were previously
+applied by `#configure`.
 
 
 ## formatStats(stats: Stats[], options: Options = {})
@@ -148,3 +151,25 @@ property.
 ### Return
 Defaults to `NS` if nothing is given. If only one char is given plural defaults
 to `S`
+
+## textToStats(text: string, options: Options = {})
+Yields every possible combination of that `Stats`s that could've produce the 
+given `text`.
+
+### Arguments <a name="textToStats-args"></a>
+- text: the text produced by some `Stat`s. This assumes that this is a single
+  stat description. This function cannot extract stats from text that was 
+  produced by unrelated stats (e.g. *40% fire resistance, Cannot be shocked* 
+  will not return stats for fire resistance and shock immunity). 
+  
+  In other words this function is an inverse of [`formatStats`](#formatStats)
+- options: options used for `formatStats`
+  ```typescript
+  type Options = {
+    datas: StatsLocaleDatas,
+    start_file: keyof StatsLocaleDatas
+  }
+  ```
+  - options.datas: see [`formatStats` args](#formatStats-args)
+  
+  - options.start_file: see [`formatStats` args](#formatStats-args)

--- a/src/Format.ts
+++ b/src/Format.ts
@@ -1,5 +1,8 @@
 import formatGemStats, { GemId } from './format/gemStats';
 import formatStats, { Stat } from './format/stats';
+import textToStats, {
+  Options as TextToStatsOptions
+} from './format/textToStats';
 import { StatLocaleDatas } from './types/StatDescription';
 
 export enum Fallback {
@@ -34,6 +37,15 @@ export class Format {
 
   public gemStats(gem_id: GemId, stats: Stat[]) {
     return formatGemStats(gem_id, stats, this.options);
+  }
+
+  public textToStats(text: string, options: Partial<TextToStatsOptions> = {}) {
+    const { datas, start_file } = this.options;
+    return textToStats(text, {
+      datas,
+      start_file,
+      ...options
+    });
   }
 }
 

--- a/src/__tests__/format.ts
+++ b/src/__tests__/format.ts
@@ -1,5 +1,6 @@
 import datas from '../__fixtures__/english';
 import format from '../Format';
+import textToStats from '../format/textToStats';
 
 it('can be configured to use global local data', () => {
   expect(() =>
@@ -11,4 +12,8 @@ it('can be configured to use global local data', () => {
   expect(
     format.stats([{ id: 'base_chance_to_freeze_%', value: 12 }]).sort()
   ).toEqual(['12% chance to Freeze']);
+
+  expect(format.textToStats('12% chance to Freeze').next().value).toEqual(
+    textToStats('12% chance to Freeze', { datas }).next().value
+  );
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 export { default as formatStats, Fallback } from './format/stats';
 export { default as formatGemStats } from './format/gemStats';
+export {
+  default as textToStats,
+  textToStatsArray,
+  textToStatsFirst
+} from './format/textToStats';
 export { default as format, Format } from './Format';
 export { default as requiredLocaleDatas } from './requiredLocaleDatas';
 export { default as formatValueRange } from './localize/formatValueRange';


### PR DESCRIPTION
Adds `textToStats` from #24 to the public API.