### PR TITLE
Guess displayed value and order range accordingly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - `textToStats` (also available in `Format`) which finds every combination
   of stats that could've produced a given text. Check the API docs for more info. (#24)
 
+### Changed
+- Value ranges should now be displayed ordered. This caused #32 and was fixed with #37.
+
 ### Fixes
 - Some translations had standard printf syntax which is not understood by
   `formatStats`. This caused #34 and is fixed with #35.

--- a/src/format/__tests__/formatStats.ts
+++ b/src/format/__tests__/formatStats.ts
@@ -311,8 +311,8 @@ describe('expensive test cases', () => {
         }
       )
     ).toEqual([
-      '(10 - 7)% chance to Freeze',
-      'Adds (16 - 13) to (36 - 33) Cold Damage against Chilled or Frozen Enemies'
+      '(7 - 10)% chance to Freeze',
+      'Adds (13 - 16) to (33 - 36) Cold Damage against Chilled or Frozen Enemies'
     ]);
   });
 });

--- a/src/localize/__tests__/formatters.ts
+++ b/src/localize/__tests__/formatters.ts
@@ -54,13 +54,20 @@ it('should match all the formats', () => {
 });
 
 it('should support ranges', () => {
-  expect(factory('negate')([-20, -10])).toBe('(20 - 10)');
+  expect(factory('negate')([-20, -10])).toBe('(10 - 20)');
   expect(factory('per_minute_to_per_second_0dp')([120, 240])).toBe('(2 - 4)');
 });
 
 it('should not display as range if min == max', () => {
   expect(factory('id')([-10, -10])).toBe('-10');
   expect(factory('id')([-10, -11])).toBe('(-10 - -11)');
+});
+
+it('orders range values', () => {
+  expect(factory('negate')([-30, -15])).toEqual('(15 - 30)');
+  expect(factory('negate')([-15, -30])).toEqual('(15 - 30)');
+  expect(factory('id')([15, 30])).toEqual('(15 - 30)');
+  expect(factory('id')([30, 15])).toEqual('(15 - 30)');
 });
 
 describe('regxp', () => {

--- a/src/localize/formatters.ts
+++ b/src/localize/formatters.ts
@@ -157,10 +157,32 @@ export default function factory(
       if (value[0] === value[1]) {
         return String(formatter(value[0]));
       } else {
-        return `(${formatter(value[0])} - ${formatter(value[1])})`;
+        const [min, max] = valueOrder(value, formatter_id);
+
+        return `(${formatter(min)} - ${formatter(max)})`;
       }
     } else {
       return String(formatter(value));
     }
   };
+}
+
+/**
+ * orders the given values so that the smallest displayed is min
+ * 
+ * reduced stats are given as negative values and then negated for display
+ * whichs results in [-30, -15] being displayed as "(30 - 15) reduced"
+ * @param param0 
+ * 
+ */
+function valueOrder(
+  [left, right]: [number, number],
+  formatter_id: string
+): [number, number] {
+  const sign = Math.sign(left);
+  if ((left < right && sign === 1) || (left > right && sign === -1)) {
+    return [left, right];
+  } else {
+    return [right, left];
+  }
 }


### PR DESCRIPTION
Closes #32.

This only guesses the displayed format.

Using negate on [10, 11} will still display `(-10 - -11)`