### PR TITLE
Remove skip_if_zero in favor of defaulting to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - `locale-data` for Path Of Exile@3.2.0 ([#28](https://github.com/eps1lon/poe-i18n/pull/28))
 - `groupMods()` to generate a fitting translation for a collection of mods 
   (e.g. mods of a `correct_group`). ([#30](https://github.com/eps1lon/poe-i18n/pull/30))
-- `skip_if_zero` fallback for `formatStats()` which suppresses thrown errors
-  if the stat has a value that is equivilant to zero. ([#29](https://github.com/eps1lon/poe-i18n/pull/29))
 - `textToStats` (also available in `Format`) which finds every combination
   of stats that could've produced a given text. Check the API docs for more info. ([#24](https://github.com/eps1lon/poe-i18n/pull/24))
 
 ### Changed
-- Value ranges should now be displayed ordered. This caused [#32](https://github.com/eps1lon/poe-i18n/issues/32) and was fixed with [#37](https://github.com/eps1lon/poe-i18n/pull/37).
+- Value ranges should now be displayed ordered. 
+  This caused [#32](https://github.com/eps1lon/poe-i18n/issues/32) and 
+  was fixed with [#37](https://github.com/eps1lon/poe-i18n/pull/37).
+
+- Stats with zero or equivalent (range 0 - 0) are now ignored by default. 
+  This matches ingame behavior. ([#29](https://github.com/eps1lon/poe-i18n/pull/29)
+  and [#39](https://github.com/eps1lon/poe-i18n/pull/39))
 
 ### Fixes
 - Some translations had standard printf syntax which is not understood by

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -154,7 +154,6 @@ declare module "format/stats" {
         throw = 0,
         id = 1,
         skip = 2,
-        skip_if_zero = 3,
     }
     const formatStats: (stats: Stat[], options?: Partial<Options>) => string[];
     export default formatStats;

--- a/src/format/__tests__/formatStats.ts
+++ b/src/format/__tests__/formatStats.ts
@@ -3,15 +3,15 @@ import { StatLocaleData } from '../../types/StatDescription';
 import datas from '../../__fixtures__/english';
 import formatStats, { Fallback, Stat } from '../stats';
 
-it('should translate single stat line', () => {
+it('should throw if the values dont match', () => {
   expect(() =>
-    formatStats([{ id: 'weapon_physical_damage_+%', value: 0 }], { datas })
+    formatStats([{ id: 'weapon_physical_damage_+%', value: -1 }], { datas })
   ).toThrowError(
     "matching translation not found for 'weapon_physical_damage_+%'"
   );
 });
 
-it('should throw if the values dont match', () => {
+it('should translate single stat line', () => {
   expect(
     formatStats([{ id: 'weapon_physical_damage_+%', value: 25 }], { datas })
   ).toEqual(['25% increased Physical Damage with Weapons']);
@@ -177,19 +177,14 @@ it('should support skipping fallback', () => {
   ).toEqual([]);
 });
 
-describe('skip_if_zero fallback', () => {
+describe('zero stats', () => {
   it('ignores stats with 0 value', () => {
     const stats = [{ id: 'weapon_physical_damage_+%', value: 0 }];
 
-    expect(() =>
-      formatStats(stats, {
-        datas
-      })
-    ).toThrow("matching translation not found for 'weapon_physical_damage_+%'");
     expect(
       formatStats(stats, {
         datas,
-        fallback: Fallback.skip_if_zero
+        fallback: Fallback.throw
       })
     ).toEqual([]);
   });
@@ -203,7 +198,7 @@ describe('skip_if_zero fallback', () => {
         ],
         {
           datas,
-          fallback: Fallback.skip_if_zero
+          fallback: Fallback.throw
         }
       )
     ).toThrow("matching translation not found for 'local_energy_shield_+%'");
@@ -213,7 +208,7 @@ describe('skip_if_zero fallback', () => {
     expect(
       formatStats([{ id: 'non_existing_zero', value: 0 }], {
         datas,
-        fallback: Fallback.skip_if_zero
+        fallback: Fallback.throw
       })
     ).toEqual([]);
   });
@@ -222,7 +217,7 @@ describe('skip_if_zero fallback', () => {
     expect(() =>
       formatStats([{ id: 'non_existing_zero', value: [0, 1] }], {
         datas,
-        fallback: Fallback.skip_if_zero
+        fallback: Fallback.throw
       })
     ).toThrow('no descriptions found for non_existing_zero');
   });

--- a/src/format/groupMods.ts
+++ b/src/format/groupMods.ts
@@ -1,8 +1,4 @@
-import formatStats, {
-  Fallback,
-  Options as FormatStatsOptions,
-  Stat
-} from './stats';
+import formatStats, { Options as FormatStatsOptions, Stat } from './stats';
 
 // arg types
 export { Stat } from './stats';
@@ -59,8 +55,7 @@ function groupStats(
         arg: i + 1,
         id: 'placeholder'
       }));
-    },
-    fallback: Fallback.skip_if_zero
+    }
   });
 
   // collapes value ranges into single placeholder


### PR DESCRIPTION
This matches ingame behavior. Stats with 0 value are usually not displayed because they are increased stats usually and therefore don't have any effect.

This was introduced in #29 as a fallback method but really should be default. Since this isn't released yet we don't have to deprecate the fallback or bump a major version.