### PR TITLE
Removed singleton export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
   `formatStats`. This caused [#34](https://github.com/eps1lon/poe-i18n/issues/34) and is fixed with [#35](https://github.com/eps1lon/poe-i18n/pull/35).
 - False positive in `base_chance_to_freeze%` which threw 
   `no param given for formatter`. This fixed [#33](https://github.com/eps1lon/poe-i18n/issues/33) with [#36](https://github.com/eps1lon/poe-i18n/pull/36).
+### Removed
+- `Format` singleton instance. We do not encourage this pattern. If you rely on
+  this pattern can easily create an additional file which exports a singleton.
+  ([#45](https://github.com/eps1lon/poe-i18n/issues/45))
+  
 
 ## [0.8.0](https://github.com/eps1lon/poe-i18n/compare/v0.7.1...v0.8.0) (2017-02-16)
 ### Added 

--- a/src/Format.ts
+++ b/src/Format.ts
@@ -18,7 +18,7 @@ export type Options = {
   start_file: string;
 };
 
-export class Format {
+export default class Format {
   private options: Options = {
     datas: {} as StatLocaleDatas,
     fallback: Fallback.throw,
@@ -53,5 +53,3 @@ export class Format {
     });
   }
 }
-
-export default new Format();

--- a/src/__tests__/format.ts
+++ b/src/__tests__/format.ts
@@ -1,6 +1,8 @@
 import datas from '../__fixtures__/english';
-import format from '../Format';
+import Format from '../Format';
 import textToStats from '../format/textToStats';
+
+const format = new Format();
 
 it('can be configured to use global local data', () => {
   expect(() =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export {
   textToStatsArray,
   textToStatsFirst
 } from './format/textToStats';
-export { default as format, Format } from './Format';
+export { default as Format } from './Format';
 export { default as requiredLocaleDatas } from './requiredLocaleDatas';
 export { default as formatValueRange } from './localize/formatValueRange';
 export { formatValue } from './localize/formatValues';


### PR DESCRIPTION
Up to the user to support this behavior. It is less opinionated and easily implemented by dependents.

Overview:
* [ ] Api documentation changed
* [x] includes changelog entry
* [x] breaking change 