### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
   - "node"
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.6.0
+  - export PATH=$HOME/.yarn/bin:$PATH
+cache:
+  yarn: true
 script:
   - yarn run lint
   - yarn run format:check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
-node_js:
-  - "node"
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.6.0
   - export PATH=$HOME/.yarn/bin:$PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [0.9.0](https://github.com/eps1lon/poe-i18n/compare/v0.8.0...v0.9.0) (2018-05-30)
 ### Added 
-- `locale-data` for Path Of Exile@3.2.4c ([#48](https://github.com/eps1lon/poe-i18n/pull/48))
-- `locale-data` for Path Of Exile@3.2.0 ([#28](https://github.com/eps1lon/poe-i18n/pull/28))
+- `locale-data` for Path Of Exile@`3.2.4c` ([#48](https://github.com/eps1lon/poe-i18n/pull/48))
+- `locale-data` for Path Of Exile@`3.2.0` ([#28](https://github.com/eps1lon/poe-i18n/pull/28))
 - `groupMods()` to generate a fitting translation for a collection of mods 
   (e.g. mods of a `correct_group`). ([#30](https://github.com/eps1lon/poe-i18n/pull/30))
 - `textToStats` (also available in `Format`) which finds every combination


### PR DESCRIPTION
Forces yarn 1.6 which removes deprecation warnings.

Also investigating why travis says it's using node10 instead of the version specified in nvmrc