### PR TITLE
build(travis): enable lockfile update for greenkeeper 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: node_js
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.6.0
   - export PATH=$HOME/.yarn/bin:$PATH
+  - yarn global add greenkeeper-lockfile@1
 cache:
   yarn: true
+before_script: greenkeeper-lockfile-update
+after_script: greenkeeper-lockfile-upload
 script:
   - yarn run lint
   - yarn run format:check


### PR DESCRIPTION
Previously greenkeeper onliy bumped versions in package.json without updating the lockfile. Later
running yarn would add unrelated noise to diffs from previous greenkeeper prs.