### PR TITLE
Typescrpt 2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/eps1lon/poe-i18n/compare/v0.10.0...HEAD)
+### Added
+- `locale-data/*/api_messages` for de, es, fr, pt, ru and th. These messages contain
+  translations relevant to item responses from the official GGG API. English 
+  translations are unnecessary because keys = values. The chinese translations
+  are not available because there exists no chinese API. ([#57](https://github.com/eps1lon/poe-i18n/pull/57))
+### Changed
+- Update to `typescript@~2.9.2`.
 
 ## [0.10.0](https://github.com/eps1lon/poe-i18n/compare/v0.9.1...v0.10.0) (2018-06-31)
 ### Added

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "tslint": "^5.7.0",
     "tslint-config-prettier": "^1.5.0",
     "tslint-eslint-rules": "^5.0.0",
-    "typescript": "^2.9.0",
+    "typescript": "~2.9.2",
     "webpack": "^4.10.1",
     "webpack-cli": "^3.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4510,9 +4510,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.9.0:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
+typescript@~2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
Minor ts versions can introduce new features that are not consumeable by earlier versions.
Increasing the minor version can therefore break compatbility with consumers that use older ts
versions. See Microsoft/typescript#14116